### PR TITLE
Now the docker host should be pulling the fresh image instead of fall…

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -48,6 +48,7 @@ jobs:
       - name: Clean up old containers
         run: |
           sudo docker rm -f $(sudo docker ps -aq)
+          sudo docker image rm stjarnstoft/mydiaryapp
       - name: Put up new containers
         run: |
           sudo docker compose --file /tmp/compose.yaml up -d


### PR DESCRIPTION
…ing back on an older one. Might be another, a better, way to achieve this.